### PR TITLE
marathon-lb 1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,10 @@ after_script:
   - docker images
 
 before_deploy:
-  - pip install docker-ci-deploy==0.2.0
+  - pip install docker-ci-deploy==0.3.0
   - docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"
 deploy:
   provider: script
-  script: dcd --tag-version "$version" --tag-latest "$IMAGE"
+  script: dcd --version "$version" --version-latest "$IMAGE"
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ env:
     - REGISTRY_USER=praekeltorgdeploy
     - secure: "awPRAuGS20cxsIbjTDncEAdh6ZaSAricmw2WKifyrAn1GsyWk+kTZgWUDuvrx2RhpshlJxAHy9ge2h2/cKn6dDGyT5XrpkZ08OXGTgE5O2jiGLYj/2+EJhBlbhMSaKJfWo2EzFvQ1fZx9l09zkqiWz6EM9itUlQosNDCLmNOvYYn1GVArKZRgrMRT8PZSV5D72EaiMMAdD7aQpXi1ziF7aq9hb5FFiJzCk9v4AIs/yGkA3nif/g6uOJTvipYcTZlbcSOz/BLGrdMXNirKpeDkp+9CDKQ05em6COR9hrvovneEFL9SA58O0WhMm1MJBLo8kwOh3M1MNYUTTbJiKkOHkZm1ZS4RNp/dpYdxQDCMkRSyaW8Ik6OhvRFrpBs96UmooDSmSUA8XCfOj1KqIaLTNzkMBY0MEuybsh9IF1swMZLBJ/HTvmJHcjYtFG41uxT6oqbrc10f39EzqI6tXwFVNqzhEN5hCMQHVRTRVKfY/ujgW8seWwx5E0LqM1RDdIlVcmqe/gmfG1dEfCvTQymlI+YkGrYwVRDPgdCWobMEhFNRv9vhC8gj91WMuRrBn1NWl7PzVc8GYpUaXJRNO9vPHKqkgavPpv4uVTbLzb6QyyuE3lyV30C07DoqfrBO3AlOXCnqNFf9GkyRZP2pR6YtzOqC9QpHd9qKL395ldCxJ4="
 
-# Update Docker Engine
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install -qy -o Dpkg::Options::="--force-confold" docker-engine
-
 before_script:
   - version="$(awk '$1 == "FROM" { print substr($2, index($2, ":v") + 2); exit }' Dockerfile)"
   # Pull the existing image to use as a build cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mesosphere/marathon-lb:v1.6.0
+FROM mesosphere/marathon-lb:v1.8.0
 LABEL maintainer "Praekelt.org <sre@praekelt.org>"
 
 COPY templates templates/


### PR DESCRIPTION
Between 1.6.0 and 1.8.0 there are 3 commits:
* mesosphere/marathon-lb@8811443: Get --auth-credentials from a VAULT instance
* mesosphere/marathon-lb@b950d72: Fixing issue with HAPROXY_{n}_MODE, where if HAPROXY_{n}_VHOST is set
* mesosphere/marathon-lb@0d850c2: dockerfile: Update to haproxy 1.7.6

The only "breaking" change is the second one, which should mean that any app that lacks a `HAPROXY_{n}_VHOST` label (and doesn't have a couple of other labels which we aren't using afaik) uses tcp proxying instead of HTTP proxying. I don't think this will affect us.